### PR TITLE
Check input parameter

### DIFF
--- a/anoncreds/protocol/types.py
+++ b/anoncreds/protocol/types.py
@@ -47,6 +47,10 @@ class AttribDef:
                          self.attrTypes + other.attrTypes)
 
     def attribs(self, **vals):
+        for k in vals:
+            # Check that keys provided in vals match the attibute names
+            # in the schema definition
+            assert k in self.attribNames()
         return Attribs(self, **vals)
 
     def attribNames(self):


### PR DESCRIPTION
The current `AttribDef.attribs` method can return anything because it does not check that the arguments provided actually match the attribute names in the schema definition. Having an assert here makes it much faster for Sovrin agent developers to quickly find mismatch that they might have in their code.