### PR TITLE
Using bash insted of sh for setup-charm.sh in Debian-based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Anonymous Credentials requires a cryptographic framework. We have tested it with
 ```
 git clone https://github.com/hyperledger/indy-anoncreds.git
 cd indy-anoncreds
-sh setup-charm.sh
+bash setup-charm.sh
 ```
 
 ## Installation on Mac


### PR DESCRIPTION
 The setup-charm.sh script is using bash syntactical feature [[ but sh is not always pointing to bash (in Ubuntu sh is pointing to dash). For Debian-based systems would be better to use command:

bash setup-charm.sh